### PR TITLE
feat: configure custom domain chaveacesso.heidiks.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Browser-based tool for decomposing and validating Brazilian electronic fiscal document access keys (chave de acesso). Parses 44-digit keys into structured fields (UF, CNPJ, model, series, etc.) with Mod 11 check digit validation. Supports 8 document models: NF-e, CT-e, NFC-e, MDF-e, BP-e, CF-e SAT, NF3e, CT-e OS.
+
+100% client-side, zero runtime dependencies, no API calls, no database.
+
+## Commands
+
+```bash
+npm run dev       # Vite dev server (localhost:5173)
+npm run build     # Production build → dist/
+npm run preview   # Preview production build
+```
+
+No test framework, linter, or type checker is configured.
+
+## Architecture
+
+Vanilla JS (ES modules) + Vite 6.2.0. No framework.
+
+### Source Layout (`src/`)
+
+- **`js/chave-acesso.js`** — Core domain logic: parsing, validation (Mod 11), lookup tables (`ESTADOS`, `MODELOS`, `TIPOS_EMISSAO`, `SEGMENTS`). Pure functions, no side effects.
+- **`js/app.js`** — UI: state management, DOM rendering, event binding. Renders entirely from a plain JS state object (`tabs[]`, `activeTabId`, `historyOpen`, etc.). Full re-render on every state change.
+- **`js/history.js`** — localStorage-based history (max 10 items) with dedup and relative time formatting.
+- **`js/theme.js`** — Dark/light theme via `data-theme` attribute, persisted in localStorage, auto-detects system preference.
+- **`js/analytics.js`** — GA4 event tracking (graceful no-op if blocked).
+- **`js/icons.js`** — Inline SVG icon functions.
+- **`css/styles.css`** — All styling. Uses CSS custom properties for theming (dark/light) and segment colors (`--seg-uf`, `--seg-cnpj`, etc.).
+- **`index.html`** — Entry point with SEO meta tags, JSON-LD structured data, and static fallback content.
+
+### Key Patterns
+
+- **State-driven rendering**: `app.js` maintains a state object and calls `render()` to rebuild the DOM. `bindEvents()` reattaches listeners after each render.
+- **Segment coloring**: Each of the 10 key segments has a CSS variable (`--seg-uf`, `--seg-ano`, etc.) mapped in `SEG_COLORS` in `app.js` and `SEGMENTS` in `chave-acesso.js`.
+- **Multi-tab**: Up to 15 tabs (`MAX_TABS`), each with independent chave/parsed/validation state. Auto-closes oldest tab when limit is reached.
+- **URL sharing**: `?chave=...&chave=...` query params load keys into tabs on init.
+- **Global paste**: Ctrl+V anywhere on the page triggers key input.
+
+### Build Config
+
+Vite root is `src/`, base path is `/` (custom domain `chaveacesso.heidiks.com`), public assets in `public/`, output to `dist/`. The `public/CNAME` file ensures GitHub Pages uses the custom domain on each deploy.
+
+## Deployment
+
+GitHub Actions (`.github/workflows/static.yml`) builds and deploys to GitHub Pages on push to `master`. Uses Node 20. Custom domain: `chaveacesso.heidiks.com`.
+
+## Language
+
+The project UI, README, and code comments are in Brazilian Portuguese. Variable names and function names are in Portuguese (e.g., `calcularDigitoVerificador`, `formatarCnpj`, `validarDigito`).

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+chaveacesso.heidiks.com

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
   <meta name="theme-color" content="#1a1a2e">
 
   <!-- Canonical -->
-  <link rel="canonical" href="https://heidiks.github.io/nfe-chave-acesso-compose/">
+  <link rel="canonical" href="https://chaveacesso.heidiks.com/">
 
   <!-- Favicon -->
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
@@ -20,10 +20,10 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="Chave de Acesso Compose — Decomposição de documentos fiscais">
   <meta property="og:description" content="Decomponha e valide chaves de acesso de NF-e, CT-e, NFC-e, MDF-e e outros documentos fiscais eletrônicos. Gratuito e sem cadastro.">
-  <meta property="og:url" content="https://heidiks.github.io/nfe-chave-acesso-compose/">
+  <meta property="og:url" content="https://chaveacesso.heidiks.com/">
   <meta property="og:locale" content="pt_BR">
   <meta property="og:site_name" content="Chave de Acesso Compose">
-  <meta property="og:image" content="https://heidiks.github.io/nfe-chave-acesso-compose/og-image.png">
+  <meta property="og:image" content="https://chaveacesso.heidiks.com/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Chave de Acesso Compose — Ferramenta de decomposição de documentos fiscais eletrônicos">
@@ -32,7 +32,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Chave de Acesso Compose">
   <meta name="twitter:description" content="Decomponha e valide chaves de acesso de documentos fiscais eletrônicos brasileiros.">
-  <meta name="twitter:image" content="https://heidiks.github.io/nfe-chave-acesso-compose/og-image.png">
+  <meta name="twitter:image" content="https://chaveacesso.heidiks.com/og-image.png">
 
   <!-- Structured Data: WebApplication -->
   <script type="application/ld+json">
@@ -40,7 +40,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "Chave de Acesso Compose",
-    "url": "https://heidiks.github.io/nfe-chave-acesso-compose/",
+    "url": "https://chaveacesso.heidiks.com/",
     "description": "Ferramenta online gratuita para decomposição e validação de chaves de acesso de documentos fiscais eletrônicos brasileiros (NF-e, CT-e, NFC-e, MDF-e, BP-e, CF-e SAT, NF3e, CT-e OS).",
     "applicationCategory": "BusinessApplication",
     "operatingSystem": "Web",

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   root: 'src',
-  base: '/nfe-chave-acesso-compose/',
+  base: '/',
   publicDir: '../public',
   build: {
     outDir: '../dist',


### PR DESCRIPTION
## Summary
- Update Vite `base` from `/nfe-chave-acesso-compose/` to `/` for custom domain serving
- Update all canonical, Open Graph, and structured data URLs to `chaveacesso.heidiks.com`
- Add `public/CNAME` to persist custom domain across GitHub Pages deploys
- Add `CLAUDE.md` with project guidance for Claude Code

## Setup required
1. **Cloudflare DNS**: Add `CNAME chaveacesso → heidiks.github.io` (Proxied)
2. **GitHub Pages**: Set custom domain to `chaveacesso.heidiks.com` in repo Settings > Pages

## Test plan
- [ ] Verify DNS propagation with `dig chaveacesso.heidiks.com`
- [ ] Confirm site loads with CSS/JS at `https://chaveacesso.heidiks.com/`
- [ ] Verify old URL `heidiks.github.io/nfe-chave-acesso-compose/` redirects to new domain
- [ ] Enable "Enforce HTTPS" in GitHub Pages settings after DNS check passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)